### PR TITLE
Add comments around unused parameters

### DIFF
--- a/source/svgelement.cpp
+++ b/source/svgelement.cpp
@@ -58,7 +58,7 @@ SVGTextNode::SVGTextNode(Document* document)
 {
 }
 
-std::unique_ptr<SVGNode> SVGTextNode::clone(bool deep) const
+std::unique_ptr<SVGNode> SVGTextNode::clone(bool /* deep */) const
 {
     auto node = std::make_unique<SVGTextNode>(document());
     node->setData(m_data);
@@ -455,7 +455,7 @@ void SVGElement::renderChildren(SVGRenderState& state) const
     }
 }
 
-void SVGElement::render(SVGRenderState& state) const
+void SVGElement::render(SVGRenderState& /* state */) const
 {
 }
 

--- a/source/svgtextelement.cpp
+++ b/source/svgtextelement.cpp
@@ -6,7 +6,7 @@
 
 namespace wxlunasvg {
 
-static float calculateBaselineOffset(const SVGTextPositioningElement* element)
+static float calculateBaselineOffset(const SVGTextPositioningElement* /* element */)
 {
     return 0.f;
 }


### PR DESCRIPTION
This causes wxWidgets build errors when warnings are converted to errors (Mac builds)